### PR TITLE
V/7/WP/3: removed the redundant use of class and retained only id

### DIFF
--- a/VTU/Sem7/WP_Lab/03_StackOrdering/3.md
+++ b/VTU/Sem7/WP_Lab/03_StackOrdering/3.md
@@ -14,7 +14,7 @@
 		<title>Stack Ordering</title>
 			<!-- Define styling properties -->
 			<style type="text/css">
-				.layer1
+				#layer1
 					{
 						border:solid thick black;
 						background-color:brown;
@@ -26,7 +26,7 @@
 						left:200px;
 						z-index:0;
 					}
-				.layer2
+				#layer2
 					{
 						border:solid thick black;
 						background-color:gray;
@@ -38,7 +38,7 @@
 						left:220px;
 						z-index:0;
 					}
-				.layer3
+				#layer3
 					{
 						border:solid thick black;
 						background-color:white;
@@ -63,9 +63,9 @@
 						topLayer=toTop;
 					}
 			</script>
-			<p class=layer1 id=layer1 onMouseOver=mover('layer1');>This is the last layer</p>
-			<p class=layer2 id=layer2 onMouseOver=mover('layer2');>This is the middle layer</p>
-			<p class=layer3 id=layer3 onMouseOver=mover('layer3');>This is the first layer</p>
+			<p id=layer1 onMouseOver=mover('layer1');>This is the last layer</p>
+			<p id=layer2 onMouseOver=mover('layer2');>This is the middle layer</p>
+			<p id=layer3 onMouseOver=mover('layer3');>This is the first layer</p>
 		</body>
      </html>
 
@@ -88,7 +88,7 @@
     		<title>Stack Ordering with moveback</title>
     			<!-- Define styling properties -->
      			<style type="text/css">
-    				.layer1
+    				#layer1
 					{
 						border:solid thick black;
 						background-color:brown;
@@ -100,7 +100,7 @@
 						left:200px;
 						z-index:1;
 					}
-				.layer2
+				#layer2
 					{
 						border:solid thick black;
 						background-color:gray;
@@ -112,7 +112,7 @@
 						left:220px;
 						z-index:2;
 					}
-				.layer3
+				#layer3
 					{
 						border:solid thick black;
 						background-color:white;
@@ -143,9 +143,9 @@
      					document.getElementById(topLayer).style.zIndex=origpos;
      				}
     		</script>
-    		<p class=layer1 id=layer1 onMouseOver=mover('layer1','1'); onMouseOut=moveBack()>This is the last layer</p>
-    		<p class=layer2 id=layer2 onMouseOver=mover('layer2','2'); onMouseOut=moveBack()>This is the middle layer</p>
-    		<p class=layer3 id=layer3 onMouseOver=mover('layer3','3'); onMouseOut=moveBack()>This is the first layer</p>
+    		<p id=layer1 onMouseOver=mover('layer1','1'); onMouseOut=moveBack()>This is the last layer</p>
+    		<p id=layer2 onMouseOver=mover('layer2','2'); onMouseOut=moveBack()>This is the middle layer</p>
+    		<p id=layer3 onMouseOver=mover('layer3','3'); onMouseOut=moveBack()>This is the first layer</p>
     	</body>
      </html>
 


### PR DESCRIPTION
1. Class names used only to identify layers in CSS
2. Removed class names and retained only id
3. Modified .layer* to #layer* in the CSS