### PR TITLE
V/7/CN/08DistanceVector: Remove unused header

### DIFF
--- a/VTU/Sem7/Networks_Lab/08DistanceVector/DSV.md
+++ b/VTU/Sem7/Networks_Lab/08DistanceVector/DSV.md
@@ -55,8 +55,6 @@ time stamps and sends back as fast as possible.
 
 ```cpp
 #include <iostream>
-#include <stdio.h>
-
 using namespace std;
 
 struct node {


### PR DESCRIPTION
iostream has the necessary functions for I/O. There is no need for stdio.h too

Compiled with g++ (GCC) 7.2.0 to verify