### PR TITLE
V/7/CN/11RSA: Improve prime check loop

### DIFF
--- a/VTU/Sem7/Networks_Lab/11RSA/rsa.md
+++ b/VTU/Sem7/Networks_Lab/11RSA/rsa.md
@@ -47,10 +47,10 @@ long int gcd(long int a, long int b)
 	return gcd(b, a%b);
 }
 
-long int isprime(long int a)
+int isprime(long int a)
 {
 	int i;
-	for(i = 2; i < a; i++){
+	for(i = 2; i <= a /2; i++){
 		if((a % i) == 0)
 			return 0;
 	}


### PR DESCRIPTION
The largest numer that can divide a non prime number is the number/2.
Reference: https://stackoverflow.com/a/14650393/3976388

Since the loop returns either 1 or 0, we can use int instead of long int